### PR TITLE
update index_history to handle CINFO prerequisite

### DIFF
--- a/nsepython/rahu.py
+++ b/nsepython/rahu.py
@@ -743,7 +743,7 @@ niftyindices_headers = {
 }
 
 def index_history(symbol,start_date,end_date):
-    data = "{'name':'"+symbol+"','startDate':'"+start_date+"','endDate':'"+end_date+"'}"
+    data = f"{{ 'cinfo': \"{{'name':'{symbol}','startDate':'{start_date}','endDate':'{end_date}'}}\" }}"
     payload = requests.post('https://niftyindices.com/Backpage.aspx/getHistoricaldatatabletoString', headers=niftyindices_headers,  data=data).json()
     payload = json.loads(payload["d"])
     payload=pd.DataFrame.from_records(payload)


### PR DESCRIPTION
It does look like that niftyindices.com has updated recently to require a new JSON primitive 'cinfo' as a pre-requiste mandate in its handling of header requests.

This should solve many recent open forum bugs/requests as well. Sad, NSE does not have any notification about these changes at their end.