### PR TITLE
avoid mangling the output in local mode

### DIFF
--- a/nsepython/rahu.py
+++ b/nsepython/rahu.py
@@ -34,10 +34,9 @@ if(mode=='local'):
     def nsefetch(payload):
         try:
             output = requests.get(payload,headers=headers).json()
-            print(output)
         except ValueError:
             s =requests.Session()
-            output = s.get("http://nseindia.com",headers=headers)
+            s.get("http://nseindia.com",headers=headers)
             output = s.get(payload,headers=headers).json()
         return output
 


### PR DESCRIPTION
in local mode:
- do not print the output unnecessarily, it is clients' prerogative 
- do not mangle the output variable as simply trying to get the main website with session headers is enough and it should not pollute the 'output' variable unnecessarily